### PR TITLE
No need to define `__init__` nor `__repr__` for InvalidItemDefinition

### DIFF
--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -24,11 +24,7 @@ class InvalidTokenException(Exception):
 
 
 class InvalidItemDefinition(Exception):
-    def __init__(self, message):
-        self.message = message
-
-    def __repr__(self):
-        return self.message
+    pass
 
 
 class APIException(Exception):


### PR DESCRIPTION
```
>>> class MyErr(Exception):
...     pass
... 
>>> try:
...     raise MyErr("My message")
... except MyErr as e:
...     print str(e)
... 
My message
```
