### PR TITLE
Adding handling of failure_url parameter as it says in the documentation

### DIFF
--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -283,7 +283,8 @@ class LaterPayClient(object):
                      skip_add_to_invoice=False,
                      transaction_reference=None,
                      consumable=False,
-                     return_url=None):
+                     return_url=None,
+                     failure_url=None):
 
         # filter out params with None value.
         data = {k: v for k, v in item_definition.data.items() if v is not None}
@@ -296,6 +297,9 @@ class LaterPayClient(object):
 
         if return_url:
             data['return_url'] = return_url
+
+        if failure_url:
+            data['failure_url'] = failure_url
 
         if transaction_reference:
 
@@ -330,7 +334,8 @@ class LaterPayClient(object):
                     skip_add_to_invoice=False,
                     transaction_reference=None,
                     consumable=False,
-                    return_url=None):
+                    return_url=None,
+                    failure_url=None):
         """
         Get the URL at which a user can start the checkout process to buy a single item.
 
@@ -345,7 +350,8 @@ class LaterPayClient(object):
             skip_add_to_invoice=skip_add_to_invoice,
             transaction_reference=transaction_reference,
             consumable=consumable,
-            return_url=return_url)
+            return_url=return_url,
+            failure_url=failure_url)
 
     def get_add_url(self,
                     item_definition,
@@ -355,7 +361,8 @@ class LaterPayClient(object):
                     skip_add_to_invoice=False,
                     transaction_reference=None,
                     consumable=False,
-                    return_url=None):
+                    return_url=None,
+                    failure_url=None):
         """
         Get the URL at which a user can add an item to their invoice to pay later.
 
@@ -370,7 +377,8 @@ class LaterPayClient(object):
             skip_add_to_invoice=skip_add_to_invoice,
             transaction_reference=transaction_reference,
             consumable=consumable,
-            return_url=return_url)
+            return_url=return_url,
+            failure_url=failure_url)
 
     def _sign_and_encode(self, params, url, method="GET"):
         return signing.sign_and_encode(self.shared_secret, params, url=url, method=method)

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -66,12 +66,6 @@ class ItemDefinition(object):
                 raise InvalidItemDefinition('Pricing is not valid: %s' % pricing)
 
         if purchasedatetime is not None and not isinstance(purchasedatetime, int):
-            warnings.warn(
-                (
-                    "The purchasedatetime parameter is deprecated and will be ignored. "
-                ),
-                DeprecationWarning
-            )
             raise InvalidItemDefinition("Invalid purchasedatetime %s. This should be a UTC-based epoch timestamp "
                                         "in seconds of type int" % purchasedatetime)
 

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -66,6 +66,12 @@ class ItemDefinition(object):
                 raise InvalidItemDefinition('Pricing is not valid: %s' % pricing)
 
         if purchasedatetime is not None and not isinstance(purchasedatetime, int):
+            warnings.warn(
+                (
+                    "The purchasedatetime parameter is deprecated and will be ignored. "
+                ),
+                DeprecationWarning
+            )
             raise InvalidItemDefinition("Invalid purchasedatetime %s. This should be a UTC-based epoch timestamp "
                                         "in seconds of type int" % purchasedatetime)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -90,6 +90,13 @@ class TestLaterPayClient(unittest.TestCase):
             'expiry url param is "None". Should be omitted.',
         )
 
+    def test_failure_url_param(self):
+        item = ItemDefinition(1, 'EUR20', 'DE19.0', 'http://help.me/', 'title')
+        url = self.lp.get_add_url(item, failure_url="http://example.com")
+        self.assertTrue('failure_url' in url)
+
+        url = self.lp.get_buy_url(item, failure_url="http://example.com")
+        self.assertTrue('failure_url' in url)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
http://local.laterpaytest.net:8001/developers/docs/dialog-api#GET/dialog/add has a failure_url parameter, this client currently doesn't. 