### PR TITLE
add deprecation warning for purchasedatetime parameter

### DIFF
--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -14,7 +14,6 @@ import logging
 import random
 import re
 import string
-import time
 
 from . import signing
 from . import compat

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -66,6 +66,12 @@ class ItemDefinition(object):
                 raise InvalidItemDefinition('Pricing is not valid: %s' % pricing)
 
         if purchasedatetime is not None and not isinstance(purchasedatetime, int):
+            warnings.warn(
+                (
+                    "The purchasedatetime parameter is deprecated and will be ignored. "
+                ),
+                DeprecationWarning
+            )
             raise InvalidItemDefinition("Invalid purchasedatetime %s. This should be a UTC-based epoch timestamp "
                                         "in seconds of type int" % purchasedatetime)
 

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -65,15 +65,8 @@ class ItemDefinition(object):
             if not re.match('[A-Z]{3}\d+', price):
                 raise InvalidItemDefinition('Pricing is not valid: %s' % pricing)
 
-        if purchasedatetime is not None and not isinstance(purchasedatetime, int):
-            warnings.warn(
-                (
-                    "The purchasedatetime parameter is deprecated and will be ignored. "
-                ),
-                DeprecationWarning
-            )
-            raise InvalidItemDefinition("Invalid purchasedatetime %s. This should be a UTC-based epoch timestamp "
-                                        "in seconds of type int" % purchasedatetime)
+        if purchasedatetime is not None:
+            warnings.warn("The purchasedatetime parameter is deprecated and will be ignored. ", DeprecationWarning)
 
         if expiry is not None and not re.match('^(\+?\d+)$', expiry):
             raise InvalidItemDefinition("Invalid expiry value %s, it should be '+3600' or UTC-based "
@@ -93,7 +86,6 @@ class ItemDefinition(object):
 
         self.data = {
             'article_id': item_id,
-            'purchasedatetime': int(time.time()) if purchasedatetime is None else purchasedatetime,
             'pricing': pricing,
             'url': url,
             'title': title,


### PR DESCRIPTION
It's deprecated according to our documentation: https://laterpay.net/developers/docs/dialog-api#GET/dialog/add