### PR TITLE
Don't encode `product_key` as part of the dialog api url path.

### DIFF
--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -308,9 +308,9 @@ class LaterPayClient(object):
             prefix = self.web_root
 
         if product_key is not None:
-            base_url = "%s/%s/%s" % (prefix, product_key, page_type)
-        else:
-            base_url = "%s/%s" % (prefix, page_type)
+            data['product'] = product_key
+
+        base_url = "%s/%s" % (prefix, page_type)
 
         params = self._sign_and_encode(data, base_url, method="GET")
         url = "{base_url}?{params}".format(base_url=base_url, params=params)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ flake8==2.2.3
 coverage==3.7.1
 coveralls
 pep257==0.3.2
+furl==0.4.7

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -104,7 +104,7 @@ class TestLaterPayClient(unittest.TestCase):
         self.assertTrue('failure_url' in url)
 
     def test_get_web_url_product_key_param(self):
-        item = ItemDefinition(1, 'EUR20', 'DE19.0', 'http://help.me/', 'title')
+        item = ItemDefinition(1, 'EUR20', 'DE19.0', 'http://example.com/', 'title')
 
         url = self.lp.get_add_url(item, product_key="hopes")
         data = self.get_qs_dict(url)
@@ -123,7 +123,7 @@ class TestLaterPayClient(unittest.TestCase):
         )
 
     def test_get_web_url_no_product_key_param(self):
-        item = ItemDefinition(1, 'EUR20', 'DE19.0', 'http://help.me/', 'title')
+        item = ItemDefinition(1, 'EUR20', 'DE19.0', 'http://example.com/', 'title')
 
         url = self.lp.get_add_url(item)
         data = self.get_qs_dict(url)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -36,6 +36,7 @@ class TestLaterPayClient(unittest.TestCase):
         self.lp = LaterPayClient(
             1,
             'some-secret')
+        self.item = ItemDefinition(1, 'EUR20', 'DE19.0', 'http://example.com/', 'title')
 
     def get_qs_dict(self, url):
         o = urlparse(url)
@@ -103,10 +104,12 @@ class TestLaterPayClient(unittest.TestCase):
         url = self.lp.get_buy_url(item, failure_url="http://example.com")
         self.assertTrue('failure_url' in url)
 
-    def test_get_web_url_product_key_param(self):
-        item = ItemDefinition(1, 'EUR20', 'DE19.0', 'http://example.com/', 'title')
-
-        url = self.lp.get_add_url(item, product_key="hopes")
+    def test_get_add_url_product_key_param(self):
+        """
+        Assert that `.get_add_url()` produces a "/dialog/add" url with
+        `product_key` "product" query param.
+        """
+        url = self.lp.get_add_url(self.item, product_key="hopes")
         data = self.get_qs_dict(url)
         self.assertEqual(data['product'], ['hopes'])
         self.assertEqual(
@@ -114,7 +117,12 @@ class TestLaterPayClient(unittest.TestCase):
             '/dialog/add',
         )
 
-        url = self.lp.get_buy_url(item, product_key="hopes")
+    def test_get_buy_url_product_key_param(self):
+        """
+        Assert that `.get_buy_url()` produces a "/dialog/buy" url with
+        `product_key` "product" query param.
+        """
+        url = self.lp.get_buy_url(self.item, product_key="hopes")
         data = self.get_qs_dict(url)
         self.assertEqual(data['product'], ['hopes'])
         self.assertEqual(
@@ -122,10 +130,12 @@ class TestLaterPayClient(unittest.TestCase):
             '/dialog/buy',
         )
 
-    def test_get_web_url_no_product_key_param(self):
-        item = ItemDefinition(1, 'EUR20', 'DE19.0', 'http://example.com/', 'title')
-
-        url = self.lp.get_add_url(item)
+    def test_get_add_url_no_product_key_param(self):
+        """
+        Assert that `.get_add_url()` produces a "/dialog/buy" url without
+        "product" query param when no `product_key` method param is used.
+        """
+        url = self.lp.get_add_url(self.item)
         data = self.get_qs_dict(url)
         self.assertNotIn('product', data)
         self.assertEqual(
@@ -133,7 +143,12 @@ class TestLaterPayClient(unittest.TestCase):
             '/dialog/add',
         )
 
-        url = self.lp.get_buy_url(item)
+    def test_get_buy_url_no_product_key_param(self):
+        """
+        Assert that `.get_buy_url()` produces a "/dialog/buy" url without
+        "product" query param when no `product_key` method param is used.
+        """
+        url = self.lp.get_buy_url(self.item)
         data = self.get_qs_dict(url)
         self.assertNotIn('product', data)
         self.assertEqual(


### PR DESCRIPTION
Instead add it as any other param (as a url query parameter).