### PR TITLE
Log request errors with exception log level.

### DIFF
--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -393,12 +393,9 @@ class LaterPayClient(object):
 
         try:
             response = compat.urlopen(req).read()
-        except compat.URLError as e:
-            _logger.debug("Request failed with reason: %s", e.reason)
-            resp = {'status': 'connection_error'}
-        except:
-            _logger.debug("Unexpected error with request")
-            resp = {'status': 'unexpected error'}
+        except Exception as e:
+            _logger.exception("Unexpected error with request: %s", e)
+            resp = {'status': 'unexpected error: %s' % e}
         else:
             _logger.debug("Received response %s", response)
             resp = json.loads(response)

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -393,9 +393,12 @@ class LaterPayClient(object):
 
         try:
             response = compat.urlopen(req).read()
-        except Exception as e:
-            _logger.exception("Unexpected error with request: %s", e)
-            resp = {'status': 'unexpected error: %s' % e}
+        except:
+            # TODO: Add proper or no exception handling.
+            # Pretending there was a response even if there was none
+            # (can't connect / timeout) seems like a wrong idea.
+            _logger.exception("Unexpected error with request")
+            resp = {'status': 'unexpected error'}
         else:
             _logger.debug("Received response %s", response)
             resp = json.loads(response)


### PR DESCRIPTION
Also:
- simplify error handling (drop `except URLError` block)
- add error repr to the status message.