### PR TITLE
Removed deprecated LaterPayClient params and methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## UNRELEASED
 
 * Added `timeout_seconds` (default value is 10) param to `LaterPayClient`. Backend API requests will time out now according to that value.
+* Removed deprecated `vat` and `purchasedatetime` params from `ItemDefinition.__init__()`. This is a backward incompatible change to `__init__(self, item_id, pricing, url, title, cp=None, expiry=None)` from `__init__(self, item_id, pricing, vat, url, title, purchasedatetime=None, cp=None, expiry=None)`.
+* Removed deprecated `add_metered_access()` and `get_metered_access()` methods from `LaterPayClient`.
 
 
 ## 3.2.1

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -58,30 +58,15 @@ class ItemDefinition(object):
     For Single item purchases: https://laterpay.net/developers/docs/dialog-api#GET/dialog/buy
     """
 
-    def __init__(self, item_id, pricing, vat, url, title, purchasedatetime=None, cp=None, expiry=None):
+    def __init__(self, item_id, pricing, url, title, cp=None, expiry=None):
 
         for price in pricing.split(','):
             if not re.match('[A-Z]{3}\d+', price):
                 raise InvalidItemDefinition('Pricing is not valid: %s' % pricing)
 
-        if purchasedatetime is not None:
-            warnings.warn("The purchasedatetime parameter is deprecated and will be ignored. ", DeprecationWarning)
-
         if expiry is not None and not re.match('^(\+?\d+)$', expiry):
             raise InvalidItemDefinition("Invalid expiry value %s, it should be '+3600' or UTC-based "
                                         "epoch timestamp in seconds of type int" % expiry)
-
-        if vat is not None:
-            warnings.warn(
-                (
-                    "The vat parameter is deprecated. "
-                    "Due to changes in EU VAT legislation, from 1st Jan 2015 "
-                    "VAT will be charged based on _customer_ location and not "
-                    "supplier location: "
-                    "http://ec.europa.eu/taxation_customs/taxation/vat/traders/e-commerce/index_en.htm"
-                ),
-                DeprecationWarning
-            )
 
         self.data = {
             'article_id': item_id,
@@ -424,66 +409,6 @@ class LaterPayClient(object):
         https://www.laterpay.net/developers/docs/backend-api#GET/gettoken
         """
         return self.lptoken is not None
-
-    def add_metered_access(self, article_id, threshold=5, product_key=None):
-        warnings.warn(
-            "`LaterPayClient.add_metered_access()` is deprecated - we are retiring"
-            " the platform feature - if you believe this will impact you, please"
-            " contact support@laterpay.net",
-            DeprecationWarning,
-        )
-
-        params = {
-            'lptoken': self.lptoken,
-            'cp': self.cp_key,
-            'threshold': threshold,
-            'feature': 'metered',
-            'period': 'monthly',
-            'article_id': article_id
-        }
-        if product_key is not None:
-            params['product'] = product_key
-
-        data = self._make_request(self._add_url, params, method='POST')
-
-        if data['status'] == 'invalid_token':
-            raise InvalidTokenException()
-
-    def get_metered_access(self, article_ids, threshold=5, product_key=None):
-        warnings.warn(
-            "`LaterPayClient.get_metered_access()` is deprecated - we are retiring"
-            " the platform feature - if you believe this will impact you, please"
-            " contact support@laterpay.net",
-            DeprecationWarning,
-        )
-
-        if not isinstance(article_ids, (list, tuple)):
-            article_ids = [article_ids]
-
-        params = {
-            'lptoken': self.lptoken,
-            'cp': self.cp_key,
-            'article_id': article_ids,
-            'feature': 'metered',
-            'threshold': threshold,
-            'period': 'monthly'
-        }
-
-        if product_key is not None:
-            params['product'] = product_key
-
-        data = self._make_request(self._access_url, params)
-        subs = data.get('subs', [])
-
-        if data['status'] == 'invalid_token':
-            raise InvalidTokenException()
-
-        if data['status'] != 'ok':
-            raise Exception()
-
-        exceeded = data.get('exceeded', False)
-
-        return data['articles'], exceeded, subs
 
     def get_access(self, article_ids, product_key=None):
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -25,9 +25,20 @@ class TestItemDefinition(unittest.TestCase):
 
     def test_item_definition(self):
         with self.assertRaises(InvalidItemDefinition):
-            ItemDefinition(1, '', '', '', 'title')
+            ItemDefinition(1, '', '', 'title')
         with self.assertRaises(InvalidItemDefinition):
-            ItemDefinition(1, 'EUR20', 'DE19.0', 'http://foo.invalid', 'title', expiry="illegal123")
+            ItemDefinition(1, 'EUR20', 'http://foo.invalid', 'title', expiry="illegal123")
+
+        it = ItemDefinition(1, 'EUR20', 'http://example.com/t', 'title', expiry='+100')
+
+        self.assertEqual(it.data, {
+            'article_id': 1,
+            'cp': None,
+            'expiry': '+100',
+            'pricing': 'EUR20',
+            'title': 'title',
+            'url': 'http://example.com/t',
+        })
 
 
 class TestLaterPayClient(unittest.TestCase):
@@ -36,7 +47,7 @@ class TestLaterPayClient(unittest.TestCase):
         self.lp = LaterPayClient(
             1,
             'some-secret')
-        self.item = ItemDefinition(1, 'EUR20', 'DE19.0', 'http://example.com/', 'title')
+        self.item = ItemDefinition(1, 'EUR20', 'http://example.com/', 'title')
 
     def get_qs_dict(self, url):
         o = urlparse(url)
@@ -56,7 +67,7 @@ class TestLaterPayClient(unittest.TestCase):
 
     def test_transaction_reference(self):
 
-        item = ItemDefinition(1, 'EUR20', 'DE19.0', 'http://foo.invalid', 'title')
+        item = ItemDefinition(1, 'EUR20', 'http://foo.invalid', 'title')
 
         _u = str(uuid.uuid4())
 
@@ -89,7 +100,7 @@ class TestLaterPayClient(unittest.TestCase):
 
     def test_get_web_url_has_no_none_params(self):
         # item with expiry not set.
-        item = ItemDefinition(1, 'EUR20', 'DE19.0', 'http://help.me/', 'title')
+        item = ItemDefinition(1, 'EUR20', 'http://help.me/', 'title')
         url = self.lp.get_add_url(item)
         self.assertFalse(
             'expiry%3DNone' in url,
@@ -97,7 +108,7 @@ class TestLaterPayClient(unittest.TestCase):
         )
 
     def test_failure_url_param(self):
-        item = ItemDefinition(1, 'EUR20', 'DE19.0', 'http://help.me/', 'title')
+        item = ItemDefinition(1, 'EUR20', 'http://help.me/', 'title')
         url = self.lp.get_add_url(item, failure_url="http://example.com")
         self.assertTrue('failure_url' in url)
 


### PR DESCRIPTION
- remove `vat` and `purchasedatetime` `__init__` params
- remove `get_metered_access()`
- remove `add_metered_access()`