### PR TITLE
Deprecate Dialog API. Allow client not to use Dialog API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Dialog API Wrapper is [deprecated](http://docs.laterpay.net/platform/dialogs/third_party_cookies/).
+* `get_buy_url()`, `get_add_url()`, `get_login_dialog_url()`, `get_signup_dialog_url()`, and `get_logout_dialog_url()` have a new `use_dialog_api` parameter that sets if the URL returned uses the Dialog API Wrapper or not. Defaults to True during the Dialog API deprecation period.
+
 
 ## 4.0.0
 

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -225,6 +225,11 @@ class LaterPayClient(object):
                                                        "&jsevents=1" if use_jsevents else "",
                                                        "&cp=%s" % self.cp_key)
         if use_dialog_api:
+            warnings.warn("The Dialog API Wrapper is deprecated and no longer recommended. "
+                          "Please set use_dialog_api to False when calling get_login_dialog_url. "
+                          "Future releases will not use the Dialog API Wrapper by default. "
+                          "See http://docs.laterpay.net/platform/dialogs/third_party_cookies/",
+                          DeprecationWarning)
             return self._get_dialog_api_url(url)
         return url
 
@@ -234,6 +239,11 @@ class LaterPayClient(object):
                                                         "&jsevents=1" if use_jsevents else "",
                                                         "&cp=%s" % self.cp_key)
         if use_dialog_api:
+            warnings.warn("The Dialog API Wrapper is deprecated and no longer recommended. "
+                          "Please set use_dialog_api to False when calling get_signup_dialog_url. "
+                          "Future releases will not use the Dialog API Wrapper by default. "
+                          "See http://docs.laterpay.net/platform/dialogs/third_party_cookies/",
+                          DeprecationWarning)
             return self._get_dialog_api_url(url)
         return url
 
@@ -243,6 +253,11 @@ class LaterPayClient(object):
                                                         "&jsevents=1" if use_jsevents else "",
                                                         "&cp=%s" % self.cp_key)
         if use_dialog_api:
+            warnings.warn("The Dialog API Wrapper is deprecated and no longer recommended. "
+                          "Please set use_dialog_api to False when calling get_logout_dialog_url. "
+                          "Future releases will not use the Dialog API Wrapper by default. "
+                          "See http://docs.laterpay.net/platform/dialogs/third_party_cookies/",
+                          DeprecationWarning)
             return self._get_dialog_api_url(url)
         return url
 
@@ -314,6 +329,11 @@ class LaterPayClient(object):
         url = "{base_url}?{params}".format(base_url=base_url, params=params)
 
         if use_dialog_api:
+            warnings.warn("The Dialog API Wrapper is deprecated and no longer recommended. "
+                          "Please set use_dialog_api to False when calling get_buy_url or get_add_url. "
+                          "Future releases will not use the Dialog API Wrapper by default. "
+                          "See http://docs.laterpay.net/platform/dialogs/third_party_cookies/",
+                          DeprecationWarning)
             return self._get_dialog_api_url(url)
         return url
 

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -219,26 +219,32 @@ class LaterPayClient(object):
     def _get_dialog_api_url(self, url):
         return '%s/dialog-api?url=%s' % (self.web_root, compat.quote_plus(url))
 
-    def get_login_dialog_url(self, next_url, use_jsevents=False):
+    def get_login_dialog_url(self, next_url, use_jsevents=False, use_dialog_api=True):
         """ Get the URL for a login page. """
         url = '%s/account/dialog/login?next=%s%s%s' % (self.web_root, compat.quote_plus(next_url),
                                                        "&jsevents=1" if use_jsevents else "",
                                                        "&cp=%s" % self.cp_key)
-        return self._get_dialog_api_url(url)
+        if use_dialog_api:
+            return self._get_dialog_api_url(url)
+        return url
 
-    def get_signup_dialog_url(self, next_url, use_jsevents=False):
+    def get_signup_dialog_url(self, next_url, use_jsevents=False, use_dialog_api=True):
         """ Get the URL for a signup page. """
         url = '%s/account/dialog/signup?next=%s%s%s' % (self.web_root, compat.quote_plus(next_url),
                                                         "&jsevents=1" if use_jsevents else "",
                                                         "&cp=%s" % self.cp_key)
-        return self._get_dialog_api_url(url)
+        if use_dialog_api:
+            return self._get_dialog_api_url(url)
+        return url
 
-    def get_logout_dialog_url(self, next_url, use_jsevents=False):
+    def get_logout_dialog_url(self, next_url, use_jsevents=False, use_dialog_api=True):
         """ Get the URL for a logout page. """
         url = '%s/account/dialog/logout?next=%s%s%s' % (self.web_root, compat.quote_plus(next_url),
                                                         "&jsevents=1" if use_jsevents else "",
                                                         "&cp=%s" % self.cp_key)
-        return self._get_dialog_api_url(url)
+        if use_dialog_api:
+            return self._get_dialog_api_url(url)
+        return url
 
     @property
     def _access_url(self):
@@ -266,7 +272,8 @@ class LaterPayClient(object):
                      transaction_reference=None,
                      consumable=False,
                      return_url=None,
-                     failure_url=None):
+                     failure_url=None,
+                     use_dialog_api=True):
 
         # filter out params with None value.
         data = {k: v for k, v in item_definition.data.items() if v is not None}
@@ -306,7 +313,9 @@ class LaterPayClient(object):
         params = self._sign_and_encode(data, base_url, method="GET")
         url = "{base_url}?{params}".format(base_url=base_url, params=params)
 
-        return self._get_dialog_api_url(url)
+        if use_dialog_api:
+            return self._get_dialog_api_url(url)
+        return url
 
     def get_buy_url(self,
                     item_definition,
@@ -317,7 +326,8 @@ class LaterPayClient(object):
                     transaction_reference=None,
                     consumable=False,
                     return_url=None,
-                    failure_url=None):
+                    failure_url=None,
+                    use_dialog_api=True):
         """
         Get the URL at which a user can start the checkout process to buy a single item.
 
@@ -333,7 +343,8 @@ class LaterPayClient(object):
             transaction_reference=transaction_reference,
             consumable=consumable,
             return_url=return_url,
-            failure_url=failure_url)
+            failure_url=failure_url,
+            use_dialog_api=use_dialog_api)
 
     def get_add_url(self,
                     item_definition,
@@ -344,7 +355,8 @@ class LaterPayClient(object):
                     transaction_reference=None,
                     consumable=False,
                     return_url=None,
-                    failure_url=None):
+                    failure_url=None,
+                    use_dialog_api=True):
         """
         Get the URL at which a user can add an item to their invoice to pay later.
 
@@ -360,7 +372,8 @@ class LaterPayClient(object):
             transaction_reference=transaction_reference,
             consumable=consumable,
             return_url=return_url,
-            failure_url=failure_url)
+            failure_url=failure_url,
+            use_dialog_api=use_dialog_api)
 
     def _sign_and_encode(self, params, url, method="GET"):
         return signing.sign_and_encode(self.shared_secret, params, url=url, method=method)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -167,6 +167,73 @@ class TestLaterPayClient(unittest.TestCase):
             '/dialog/buy',
         )
 
+    def test_get_buy_url_with_use_dialog_api_false(self):
+        """
+        Assert that `.get_buy_url()` returns a direct buy url, with no
+        dialog-api iframe, when `use_dialog_api=False`
+        """
+        url = self.lp.get_buy_url(self.item, use_dialog_api=False)
+        self.assertEqual(str(furl(url).path), '/dialog/buy')
+
+    def test_get_add_url_with_use_dialog_api_false(self):
+        """
+        Assert that `.get_add_url()` returns a direct add url, with no
+        dialog-api iframe, when `use_dialog_api=False`
+        """
+        url = self.lp.get_add_url(self.item, use_dialog_api=False)
+        self.assertEqual(str(furl(url).path), '/dialog/add')
+
+    def test_get_login_dialog_url_with_use_dialog_api_false(self):
+        """
+        Assert that `.get_login_dialog_url()` returns a url with no
+        dialog-api iframe, when `use_dialog_api=False`
+        """
+        url = self.lp.get_login_dialog_url('http://example.org',
+                                           use_dialog_api=False)
+        self.assertEqual(str(furl(url).path), '/account/dialog/login')
+
+    def test_get_login_dialog_url_without_use_dialog_api(self):
+        """
+        Assert that `.get_login_dialog_url()` returns a url with no
+        dialog-api iframe, when `use_dialog_api` is not set (default)
+        """
+        url = self.lp.get_login_dialog_url('http://example.org')
+        self.assertEqual(str(furl(url).path), '/dialog-api')
+
+    def test_get_logout_dialog_url_with_use_dialog_api_false(self):
+        """
+        Assert that `.get_logout_dialog_url()` returns a url with no
+        dialog-api iframe, when `use_dialog_api=False`
+        """
+        url = self.lp.get_logout_dialog_url('http://example.org',
+                                            use_dialog_api=False)
+        self.assertEqual(str(furl(url).path), '/account/dialog/logout')
+
+    def test_get_logout_dialog_url_without_use_dialog_api(self):
+        """
+        Assert that `.get_logout_dialog_url()` returns a url with no
+        dialog-api iframe, when `use_dialog_api` is not set (default)
+        """
+        url = self.lp.get_logout_dialog_url('http://example.org')
+        self.assertEqual(str(furl(url).path), '/dialog-api')
+
+    def test_get_signup_dialog_url_with_use_dialog_api_false(self):
+        """
+        Assert that `.get_signup_dialog_url()` returns a url with no
+        dialog-api iframe, when `use_dialog_api=False`
+        """
+        url = self.lp.get_signup_dialog_url('http://example.org',
+                                            use_dialog_api=False)
+        self.assertEqual(str(furl(url).path), '/account/dialog/signup')
+
+    def test_get_signup_dialog_url_without_use_dialog_api(self):
+        """
+        Assert that `.get_signup_dialog_url()` returns a url with no
+        dialog-api iframe, when `use_dialog_api` is not set (default)
+        """
+        url = self.lp.get_signup_dialog_url('http://example.org')
+        self.assertEqual(str(furl(url).path), '/dialog-api')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Every method that creates URLs with dialog-api will now have a `use_dialog_api` parameter, defaulting to `True` for backwards compatibility.

DeprecationWarning is raised when `use_dialog_api` is `True`, linking to http://docs.laterpay.net/platform/dialogs/third_party_cookies/