### PR TITLE
Make client use its cp_key instead of getting it from ItemDefinition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Dialog API Wrapper is [deprecated](http://docs.laterpay.net/platform/dialogs/third_party_cookies/).
 * `get_buy_url()`, `get_add_url()`, `get_login_dialog_url()`, `get_signup_dialog_url()`, and `get_logout_dialog_url()` have a new `use_dialog_api` parameter that sets if the URL returned uses the Dialog API Wrapper or not. Defaults to True during the Dialog API deprecation period.
-* ItemDefinition no longer requires a `cp` argument.
+* `ItemDefinition` no longer requires a `cp` argument.
 
 
 ## 4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Dialog API Wrapper is [deprecated](http://docs.laterpay.net/platform/dialogs/third_party_cookies/).
 * `get_buy_url()`, `get_add_url()`, `get_login_dialog_url()`, `get_signup_dialog_url()`, and `get_logout_dialog_url()` have a new `use_dialog_api` parameter that sets if the URL returned uses the Dialog API Wrapper or not. Defaults to True during the Dialog API deprecation period.
+* ItemDefinition no longer requires a `cp` argument.
 
 
 ## 4.0.0

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -69,7 +69,7 @@ class ItemDefinition(object):
                                         "epoch timestamp in seconds of type int" % expiry)
 
         if cp is not None:
-            warnings.warn("ItemDefinition's  cp parameter is deprecated and will be ignored. ", DeprecationWarning)
+            warnings.warn("ItemDefinition's cp parameter is deprecated and will be ignored.", DeprecationWarning)
 
         self.data = {
             'article_id': item_id,

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -68,12 +68,14 @@ class ItemDefinition(object):
             raise InvalidItemDefinition("Invalid expiry value %s, it should be '+3600' or UTC-based "
                                         "epoch timestamp in seconds of type int" % expiry)
 
+        if cp is not None:
+            warnings.warn("ItemDefinition's  cp parameter is deprecated and will be ignored. ", DeprecationWarning)
+
         self.data = {
             'article_id': item_id,
             'pricing': pricing,
             'url': url,
             'title': title,
-            'cp': cp,
             'expiry': expiry,
         }
 

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -292,6 +292,7 @@ class LaterPayClient(object):
 
         # filter out params with None value.
         data = {k: v for k, v in item_definition.data.items() if v is not None}
+        data['cp'] = self.cp_key
 
         if use_jsevents:
             data['jsevents'] = 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,7 +33,6 @@ class TestItemDefinition(unittest.TestCase):
 
         self.assertEqual(it.data, {
             'article_id': 1,
-            'cp': None,
             'expiry': '+100',
             'pricing': 'EUR20',
             'title': 'title',


### PR DESCRIPTION
* make `_get_web_url` use `cp_key` from client instead of `ItemDefinition` (every other LaterPayClient method does this)
* deprecate `ItemDefinition`'s `cp` parameter 