### PR TITLE
Fix docs link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Installation
 Usage
 -----
 
-See https://www.laterpay.net/developers/docs
+See http://docs.laterpay.net/
 
 Development
 -----------


### PR DESCRIPTION
This still isn't really "good client documentation" but at least it's
more accurate and useful than what was there