### PR TITLE
Deprecate `signing.sign_get_url()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-TBD
+* `signing.sign_get_url()` is deprecated and will be removed in a future release.
+
 
 ## 4.1.0
 

--- a/laterpay/signing.py
+++ b/laterpay/signing.py
@@ -5,6 +5,7 @@ import functools
 import hashlib
 import hmac
 import time
+import warnings
 
 from . import compat
 
@@ -240,6 +241,8 @@ def sign_and_encode(secret, params, url, method="GET"):
 
 def sign_get_url(secret, url, signature_paramname="hmac"):
     """
+    Deprecated.
+
     Sign a URL to be GET-ed.
 
     This function takes a URL, parses it, sorts the URL parameters in
@@ -261,6 +264,13 @@ def sign_get_url(secret, url, signature_paramname="hmac"):
     :type signature_paramname: str
     :returns: ``str`` -- the URL, including the signature as an URL parameter
     """
+    warnings.warn(
+        "sign_get_url is deprecated. It will be removed in a future release. "
+        "It wasn't intended for public use. It's recommended to use the core "
+        "signing API which is sign() and verify().",
+        DeprecationWarning,
+    )
+
     parsed = compat.urlparse(url)
 
     if parsed.query != "":


### PR DESCRIPTION
- This function is believed to be unused
- It's untested
- provides functionality which shouldn't be a part of this module.
  `signing` module should be kept minimal i.e. should expose only `sign()`
  and `verify()`