### PR TITLE
Add `LaterPayClient.get_access_data()` and deprecate `.get_access()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-* `signing.sign_get_url()` is deprecated and will be removed in a future release.
+* `signing.sign_get_url()` is deprecated and will be removed in a future
+  release.
+* `LaterPayClient.get_access()` is deprecated and will be removed in a future
+  release. Consider using `LaterPayClient.get_access_data()` instead.
 
 
 ## 4.1.0

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -449,10 +449,19 @@ class LaterPayClient(object):
 
     def get_access(self, article_ids, product_key=None):
         """
+        Deprecated. Consider using ``.get_access_data()`` instead.
+
         Get access data for a set of article ids.
 
         https://www.laterpay.net/developers/docs/backend-api#GET/access
         """
+        warnings.warn(
+            "LaterPayClient.get_access() is deprecated "
+            "and will be removed in a future release. "
+            "Consider using ``.get_access_data()`` instead.",
+            DeprecationWarning,
+        )
+
         if not isinstance(article_ids, (list, tuple)):
             article_ids = [article_ids]
 

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -14,11 +14,12 @@ import logging
 import random
 import re
 import string
-
-from . import signing
-from . import compat
-
+import time
 import warnings
+
+import requests
+
+from . import compat, signing
 
 
 _logger = logging.getLogger(__name__)
@@ -472,3 +473,76 @@ class LaterPayClient(object):
             raise Exception(data['status'])
 
         return data
+
+    def get_request_headers(self):
+        """
+        Return a ``dict`` of request headers to be sent to the API.
+        """
+        return {
+            'X-LP-APIVersion': 2,
+            # TODO: Add client version information.
+            'User-Agent': 'LaterPay Client Python',
+        }
+
+    def get_access_url(self):
+        """
+        Return the base url for /access endpoint.
+
+        Example: https://api.laterpay.net/access
+        """
+        return self._access_url
+
+    def get_access_params(self, article_ids, lptoken=None):
+        """
+        Return a params ``dict`` for /access call.
+
+        A correct signature is included in the dict as the "hmac" param.
+
+        :param article_ids: list of article ids or a single article id as a
+                            string
+        :param lptoken: optional lptoken as `str`
+        """
+        if not isinstance(article_ids, (list, tuple)):
+            article_ids = [article_ids]
+
+        params = {
+            'cp': self.cp_key,
+            'ts': str(int(time.time())),
+            'lptoken': str(lptoken or self.lptoken),
+            'article_id': article_ids,
+        }
+
+        params['hmac'] = signing.sign(
+            secret=self.shared_secret,
+            params=params.copy(),
+            url=self.get_access_url(),
+            method='GET',
+        )
+
+        return params
+
+    def get_access_data(self, article_ids, lptoken=None):
+        """
+        Perform a request to /access API and return obtained data.
+
+        This method uses ``requests.get`` to fetch the data and then calls
+        ``.raise_for_status()`` on the response. It does not handle any errors
+        raised by ``requests`` API.
+
+        :param article_ids: list of article ids or a single article id as a
+                            string
+        :param lptoken: optional lptoken as `str`
+        """
+        params = self.get_access_params(article_ids=article_ids, lptoken=lptoken)
+        url = self.get_access_url()
+        headers = self.get_request_headers()
+
+        response = requests.get(
+            url,
+            params=params,
+            headers=headers,
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+
+        return response.json()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,5 @@ coverage==3.7.1
 coveralls
 pep257==0.3.2
 furl==0.4.7
+mock==1.3.0
+responses==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,10 @@ setup(
     packages=_packages,
     package_data={'laterpay.django': ['templates/laterpay/inclusion/*']},
 
+    install_requires=[
+        'requests',
+    ],
+
     classifiers=(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function
 
+import json
 import sys
 import uuid
 
@@ -9,6 +10,9 @@ if sys.version_info[:2] < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
+
+import mock
+import responses
 
 from furl import furl
 
@@ -232,6 +236,70 @@ class TestLaterPayClient(unittest.TestCase):
         """
         url = self.lp.get_signup_dialog_url('http://example.org')
         self.assertEqual(str(furl(url).path), '/dialog-api')
+
+    @mock.patch('laterpay.signing.sign')
+    @mock.patch('time.time')
+    @responses.activate
+    def test_get_access_data_success(self, time_time_mock, sign_mock):
+        time_time_mock.return_value = 123
+        sign_mock.return_value = 'fake-signature'
+        responses.add(
+            responses.GET,
+            'http://example.net/access',
+            body=json.dumps({
+                "status": "ok",
+                "articles": {
+                    "article-1": {"access": True},
+                    "article-2": {"access": False},
+                },
+            }),
+            status=200,
+            content_type='application/json',
+        )
+
+        client = LaterPayClient(
+            'fake-cp-key',
+            'fake-shared-secret',
+            api_root='http://example.net',
+        )
+
+        data = client.get_access_data(
+            ['article-1', 'article-2'],
+            lptoken='fake-lptoken',
+        )
+
+        self.assertEqual(data, {
+            "status": "ok",
+            "articles": {
+                "article-1": {"access": True},
+                "article-2": {"access": False},
+            },
+        })
+        self.assertEqual(len(responses.calls), 1)
+
+        call = responses.calls[0]
+
+        self.assertEqual(call.request.headers['X-LP-APIVersion'], 2)
+
+        qd = parse_qs(urlparse(call.request.url).query)
+
+        self.assertEqual(qd['ts'], ['123'])
+        self.assertEqual(qd['lptoken'], ['fake-lptoken'])
+        self.assertEqual(qd['cp'], ['fake-cp-key'])
+        self.assertEqual(qd['article_id'], ['article-1', 'article-2'])
+        self.assertEqual(qd['hmac'], ['fake-signature'])
+
+        sign_mock.assert_called_once_with(
+            secret='fake-shared-secret',
+            params={
+                'cp': 'fake-cp-key',
+                'article_id': ['article-1', 'article-2'],
+                'ts': '123',
+                'lptoken': 'fake-lptoken',
+            },
+            url='http://example.net/access',
+            method='GET',
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Other new methods:
- `.get_request_headers()`
- `.get_access_url()`
- `.get_access_params()`

`.get_access_data()` uses `requests` library.