### PR TITLE
Deprecate `LaterPayClient.get_identify_url()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   release.
 * `LaterPayClient.get_access()` is deprecated and will be removed in a future
   release. Consider using `LaterPayClient.get_access_data()` instead.
+* `LaterPayClient.get_identify_url()` is deprecated and will be removed in a future
+  release.
 
 
 ## 4.1.0

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -132,6 +132,15 @@ class LaterPayClient(object):
         return url
 
     def get_identify_url(self, identify_callback=None):
+        """
+        Deprecated.
+        """
+        warnings.warn(
+            "LaterPayClient.get_identify_url() is deprecated "
+            "and will be removed in a future release.",
+            DeprecationWarning,
+        )
+
         base_url = self._identify_url
         data = {'cp': self.cp_key}
 


### PR DESCRIPTION
The backing API is being deprecated and is not used.