### PR TITLE
Deprecate skip_add_to_invoice 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 
 ## Unreleased
+* The parameter `skip_add_to_invoice` in `LaterPayClient.get_add_url()` and 
+  `LaterPayClient.get_buy_url()` is deprecated and will be removed in a future
+  release.
 
 
 ## 4.2.0

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -320,7 +320,8 @@ class LaterPayClient(object):
             data['tref'] = transaction_reference
 
         if skip_add_to_invoice:
-            data['skip_add_to_invoice'] = 1
+            warnings.warn('The param skip_add_to_invoice is deprecated and it '
+                          'will be removed in a future release.')
 
         if dialog:
             prefix = '%s/%s' % (self.web_root, 'dialog')

--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -321,7 +321,7 @@ class LaterPayClient(object):
 
         if skip_add_to_invoice:
             warnings.warn('The param skip_add_to_invoice is deprecated and it '
-                          'will be removed in a future release.')
+                          'will be removed in a future release.', DeprecationWarning)
 
         if dialog:
             prefix = '%s/%s' % (self.web_root, 'dialog')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -112,7 +112,8 @@ class TestLaterPayClient(unittest.TestCase):
                             use_dialog_api=False)
         warning_mock.assert_called_once_with("The param skip_add_to_invoice is "
                                              "deprecated and it will be removed "
-                                             "in a future release.")
+                                             "in a future release.",
+                                             DeprecationWarning)
 
 
     def test_failure_url_param(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -105,6 +105,16 @@ class TestLaterPayClient(unittest.TestCase):
             'expiry url param is "None". Should be omitted.',
         )
 
+    @mock.patch('laterpay.warnings.warn')
+    def test_log_warning_for_skip_add_to_invoice_deprecation(self, warning_mock):
+        item = ItemDefinition(1, 'EUR20', 'http://help.me/', 'title')
+        self.lp.get_add_url(item, skip_add_to_invoice=True,
+                            use_dialog_api=False)
+        warning_mock.assert_called_once_with("The param skip_add_to_invoice is "
+                                             "deprecated and it will be removed "
+                                             "in a future release.")
+
+
     def test_failure_url_param(self):
         item = ItemDefinition(1, 'EUR20', 'http://help.me/', 'title')
         url = self.lp.get_add_url(item, failure_url="http://example.com")


### PR DESCRIPTION
This PR is to deprecate the `skip_add_to_invoice` from API as it is no longer supported.