### PR TITLE
Pass a dict of params to `sign()` from `signed_query()` util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+* `laterpay.utils.signed_query()` now passes a `dict` params instance to
+  `laterpay.signing.sign()` which makes it compatible with `sign()` ignoring
+  some params being ignored by `sign()` by looking them up with `in` operator.
+
 
 ## 4.3.0
 

--- a/laterpay/utils.py
+++ b/laterpay/utils.py
@@ -42,14 +42,14 @@ def signed_query(secret,
     if "ts" not in params and add_timestamp:
         params["ts"] = str(int(time.time()))
 
-    params = [
+    param_list = [
         (encode_if_unicode(key),
          [encode_if_unicode(v) for v in val]
          if isinstance(val, (list, tuple)) else encode_if_unicode(val))
         for key, val in params.items()
     ]
 
-    qs = urlencode(params, doseq=True)
+    qs = urlencode(param_list, doseq=True)
 
     signature = signing.sign(secret, params, url=url, method=method)
 


### PR DESCRIPTION
This makes it compatible with `sign()` currently ignoring
some params by looking them up using Python's `in` operator.