### PR TITLE
Fix #81: Use only strings in headers

### DIFF
--- a/laterpay/__init__.py
+++ b/laterpay/__init__.py
@@ -421,10 +421,7 @@ class LaterPayClient(object):
         """
         params = self._sign_and_encode(params=params, url=url, method=method)
 
-        headers = {
-            'X-LP-APIVersion': 2,
-            'User-Agent': 'LaterPay Client - Python - v0.2'
-        }
+        headers = self.get_request_headers()
 
         if method == 'POST':
             req = Request(url, data=params, headers=headers)
@@ -503,7 +500,7 @@ class LaterPayClient(object):
         Return a ``dict`` of request headers to be sent to the API.
         """
         return {
-            'X-LP-APIVersion': 2,
+            'X-LP-APIVersion': '2',
             # TODO: Add client version information.
             'User-Agent': 'LaterPay Client Python',
         }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -302,7 +302,7 @@ class TestLaterPayClient(unittest.TestCase):
 
         call = responses.calls[0]
 
-        self.assertEqual(call.request.headers['X-LP-APIVersion'], 2)
+        self.assertEqual(call.request.headers['X-LP-APIVersion'], '2')
 
         qd = parse_qs(urlparse(call.request.url).query)
 


### PR DESCRIPTION
This is required as of requests>=2.11