### PR TITLE
Fixed #93 -- Ignored HMAC character capitalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 5.1.0 (under development)
 
+* Ignored HMAC character capitalization
+  ([#93](https://github.com/laterpay/laterpay-client-python/issues/93))
+
 ## 5.0.0
 
 * Removed the following long deprecated methods from the

--- a/laterpay/signing.py
+++ b/laterpay/signing.py
@@ -27,6 +27,7 @@ def time_independent_HMAC_compare(a, b):
     if len(a) != len(b):
         return False
     result = 0
+    a, b = a.lower(), b.lower()
     for x, y in zip(a, b):
         result |= ord(x) ^ ord(y)
     return result == 0

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -138,8 +138,9 @@ class TestSigningHelper(unittest.TestCase):
 
         secret = 'secret'
 
+        # Use some upper case characters to test for issue #93
         verified = signing.verify(
-            b'346f3d53ad762f3ed3fb7f2427dec2bbfaf0338bb7f91f0460aff15c',
+            b'346f3d53ad762f3ed3fb7f2427deC2BBFAF0338BB7F91F0460AFF15C',
             secret,
             params,
             url,
@@ -153,8 +154,9 @@ class TestSigningHelper(unittest.TestCase):
             'param2': ['value2', 'value3'],
         }
         url = u'https://endpoint.com/api'
+        # Use some upper case characters to test for issue #93
         verified = signing.verify(
-            u'346f3d53ad762f3ed3fb7f2427dec2bbfaf0338bb7f91f0460aff15c',
+            u'346F3D53AD762F3ED3FB7F2427DEc2bbfaf0338bb7f91f0460aff15c',
             u'secret',
             params,
             url,


### PR DESCRIPTION
It doesn't really matter if an HMAC is `12AB3` or `12ab3`. In the end
they are the same.