### PR TITLE
Add Python 3.7 to the test matrix, drop Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,4 @@
 language: python
-python:
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - 3.6
-sudo: false
 install:
   - pip install tox coveralls
 script:
@@ -13,3 +6,22 @@ script:
   - coveralls
 matrix:
   fast_finish: true
+  include:
+    - python: 2.7
+      dist: trusty
+      sudo: false
+    - python: 3.3
+      dist: trusty
+      sudo: false
+    - python: 3.4
+      dist: trusty
+      sudo: false
+    - python: 3.5
+      dist: trusty
+      sudo: false
+    - python: 3.6
+      dist: trusty
+      sudo: false
+    - python: 3.7
+      dist: xenial
+      sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
     - python: 2.7
       dist: trusty
       sudo: false
-    - python: 3.3
-      dist: trusty
-      sudo: false
     - python: 3.4
       dist: trusty
       sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
     - python: 2.7
       dist: trusty
       sudo: false
-    - python: 3.4
-      dist: trusty
-      sudo: false
     - python: 3.5
       dist: trusty
       sudo: false


### PR DESCRIPTION
This requires changing how we create the test matrix, as there are no Ubuntu "trusty" distributions available of Python 3.7 for Travis.

cf https://docs.travis-ci.com/user/languages/python/

Our tests don't pass on Python 3.3 due to failing to import "suppress". This is only supported on Python 3.4[1] and up. Python 3.3 reached end-of-life in 2017[2], so it makes sense to drop support for that now.

1. https://docs.python.org/3/library/contextlib.html#contextlib.suppress
2. https://www.python.org/dev/peps/pep-0398/#lifespan